### PR TITLE
Parent schema has beend changed

### DIFF
--- a/scripts/obographs-solr.py
+++ b/scripts/obographs-solr.py
@@ -162,7 +162,7 @@ def obographs2solr(obo, curie_map, filters):
 
             # Adding parent information
             # Do you want to see IRI or Short form?
-            se["parent"] = []
+            se["parent"] = {}
             if 'Animal_cell' in se['facets_annotation']:
                 se["parent"] = edge.get(id)
 


### PR DESCRIPTION
Fixing an issue related with initiating parent schema as list. Parent section of the solr.json should be suitable to hold IRI-label pairs of the parent terms as dict.
Changing list initialization to dict initialization.